### PR TITLE
[tweak] "Game for {user.mention}:"

### DIFF
--- a/the_prestige.py
+++ b/the_prestige.py
@@ -553,7 +553,7 @@ async def watch_game(channel, newgame, user = None):
     in_emoji = discord.utils.get(client.emojis, id = 791578957244792832)
 
     if user is not None:
-        await channel.send(f"Game for {user.display_name}:")
+        await channel.send(f"Game for {user.mention}:")
     embed = await channel.send("Starting...")
     await asyncio.sleep(1)
     await embed.pin()


### PR DESCRIPTION
`user.display_name` doesn't tag the user who requested the game. Using `user.mention` makes at tags, which also means users can search for games using Discord search (`Game for mentions:@foobar from:the_prestige#4536`)