### PR TITLE
Encourage emoji to be drawn as images

### DIFF
--- a/games.py
+++ b/games.py
@@ -884,7 +884,7 @@ class weather(object):
 
     def __init__(self, new_name, new_emoji):
         self.name = new_name
-        self.emoji = new_emoji
+        self.emoji = new_emoji + "\uFE00"
         self.counter_away = 0
         self.counter_home = 0
 


### PR DESCRIPTION
Appends the "Unicode Variation Selector 1" character to all weather emoji. This will tell systems to draw the emoji as images instead of text if able. Currently the snowflake for heavy snow defaults to text on windows 10, similar to the Moist Talkers' ORB logo on blaseball.com.
This change is untested and extremely minor, but it's been slightly annoying me and I wanted to fix it.